### PR TITLE
Security fix: Replace compromised polyfill.io with Cloudflare alternative

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,6 @@ extra_css:
 markdown_extensions:
   - admonition
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - https://kit.fontawesome.com/a076d05399.js

--- a/site/00_01_pfs_pipeline/index.html
+++ b/site/00_01_pfs_pipeline/index.html
@@ -250,7 +250,7 @@ Significant contributions have also been made by Robert Lupton, Kiyoto Yabe, and
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/01_01_install_prepare/index.html
+++ b/site/01_01_install_prepare/index.html
@@ -216,7 +216,7 @@ $ PREFIX=$WORKDIR/(username) ./install.sh
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/01_02_install_pipe2d/index.html
+++ b/site/01_02_install_pipe2d/index.html
@@ -227,7 +227,7 @@ $ git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/01_03_integration_test/index.html
+++ b/site/01_03_integration_test/index.html
@@ -184,7 +184,7 @@ $ pfs_integration_test.sh -c 4 .
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/02_01_run_prepare/index.html
+++ b/site/02_01_run_prepare/index.html
@@ -238,7 +238,7 @@ $ butler write-curated-calibrations $DATASTORE PFS
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/02_02_run_ingestion/index.html
+++ b/site/02_02_run_ingestion/index.html
@@ -293,7 +293,7 @@ You can use <code>butler.get("raw.exposure", ...)</code> to get the exposure fro
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/02_03_run_calib/index.html
+++ b/site/02_03_run_calib/index.html
@@ -440,7 +440,7 @@ butlerCleanRun.py $DATASTORE $RERUN/fiberNorms/* postISRCCD
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/02_04_run_science/index.html
+++ b/site/02_04_run_science/index.html
@@ -290,7 +290,7 @@ pfsObject = butler.get(&quot;pfsCoadd.single&quot;, cat_id=1, combination=&quot;
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/02_05_run_qa/index.html
+++ b/site/02_05_run_qa/index.html
@@ -195,7 +195,7 @@ The `fiberNormsQA` is to monitor fiber throughput variation in the long-term.
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/03_01_ana_file/index.html
+++ b/site/03_01_ana_file/index.html
@@ -196,7 +196,7 @@ Here is a brief summary of some of the most important files: <code>pfsArm</code>
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/03_02_ana_visit/index.html
+++ b/site/03_02_ana_visit/index.html
@@ -275,7 +275,7 @@ plt.show()
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/03_03_ana_coadd/index.html
+++ b/site/03_03_ana_coadd/index.html
@@ -184,7 +184,7 @@ for objId in objId_list:
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/03_04_ana_1d/index.html
+++ b/site/03_04_ana_1d/index.html
@@ -168,7 +168,7 @@
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/04_00_faq_general/index.html
+++ b/site/04_00_faq_general/index.html
@@ -168,7 +168,7 @@
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/04_01_faq_install/index.html
+++ b/site/04_01_faq_install/index.html
@@ -156,7 +156,7 @@
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/04_02_faq_run/index.html
+++ b/site/04_02_faq_run/index.html
@@ -156,7 +156,7 @@
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/04_03_faq_analysis/index.html
+++ b/site/04_03_faq_analysis/index.html
@@ -156,7 +156,7 @@
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/05_01_app_datamodel/index.html
+++ b/site/05_01_app_datamodel/index.html
@@ -654,7 +654,7 @@ Written out using <code>%016x</code> format for compactness.</p>
     <script>var base_url = "..";</script>
     <script src="../js/theme_extra.js"></script>
     <script src="../js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="../search/main.js"></script>

--- a/site/404.html
+++ b/site/404.html
@@ -151,7 +151,7 @@
     <script>var base_url = "/pfs_helpdesk_tutorial/";</script>
     <script src="/pfs_helpdesk_tutorial/js/theme_extra.js"></script>
     <script src="/pfs_helpdesk_tutorial/js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="/pfs_helpdesk_tutorial/search/main.js"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -427,7 +427,7 @@ You can find the parameters listed below:</p>
     <script>var base_url = ".";</script>
     <script src="js/theme_extra.js"></script>
     <script src="js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="search/main.js"></script>

--- a/site/search.html
+++ b/site/search.html
@@ -158,7 +158,7 @@
     <script>var base_url = ".";</script>
     <script src="./js/theme_extra.js"></script>
     <script src="./js/theme.js"></script>
-      <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+      <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
       <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
       <script src="https://kit.fontawesome.com/a076d05399.js"></script>
       <script src="./search/main.js"></script>


### PR DESCRIPTION
The website has recently been showing unexpected login requests, which is caused by the polyfill.io CDN that is referenced in the site and was likely used when originally building the site. This is a possible malicious phishing attempt used by the CDN, so I have replaced the code with a safe cloudflare alternative to get rid of the login prompts. The only change is the above and nothing else on the main branch was changed for now.

Important: Merging this PR alone will not fix the live site. The site will need to be manually redeployed (mkdocs gh-deploy) after merging for the fix to take effect.