### PR TITLE
Add GitHub Actions auto-deploy workflow to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy MkDocs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: pip install mkdocs mkdocs-material
+
+      - name: Deploy
+        run: mkdocs gh-deploy --force


### PR DESCRIPTION
Currently the site needs to be manually re-deployed every time a PR merge is made to the main branch.

This is a minor change that auto-deploys any changes made to main to the site to streamline the process.